### PR TITLE
fix behavior of generating examples JS

### DIFF
--- a/docs-src/generate.js
+++ b/docs-src/generate.js
@@ -20,7 +20,11 @@ function genJS(items) {
   imports.push(`import {render} from 'react-dom'`)
 
   items.forEach((item) => {
+    // remove any cached require calls for the existing example file so that
+    // we can access new exports for rendering
+    delete require.cache[item.examples]
     const mod = require(item.examples)
+
     Object.keys(mod).forEach((key) => {
       const id = `${item.name}_examples_${key}`
       ids.push(id)


### PR DESCRIPTION
connects to #14 

added a code comment, but the underlying issue was that our `require` calls were cached resulting in an issue where we weren't loading any new exported methods from the module for the generator to process.
