### PR TITLE
Renders AccordionItem's div with display:none

### DIFF
--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -31,14 +31,18 @@ class AccordionItem extends Component {
       'is-active': active,
     })
 
-    const div = active ? (
+    const divClassName = classNames('accordion-content', 'rev-AccordionItem-content', {
+      'is-active': active,
+    })
+
+    const div = (
       <div
-        style={{display: 'block'}}
-        className="accordion-content rev-AccordionItem-content is-active"
+        style={{display: active ? 'block' : 'none'}}
+        className={divClassName}
       >
         {children}
       </div>
-    ) : null
+    )
 
     return (
       <li {...props} className={liClassName}>


### PR DESCRIPTION
Updates AccordionItem to render its inner div with display:none when not active instead of not rendering it at all.