### PR TITLE
Fixes modal bug by syncing class names

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -98,13 +98,13 @@ export default class Pagination extends Component {
     const {hideArrows} = this.props
 
     if (!relevant && hideArrows && samePage) {
-      return 'Pagination-arrow is-hidden is-disabled'
+      return 'rev-Pagination-arrow is-hidden is-disabled'
     } else if (!relevant && hideArrows) {
-      return 'Pagination-arrow is-onlyMobile'
+      return 'rev-Pagination-arrow is-onlyMobile'
     } else if (samePage) {
-      return 'Pagination-arrow is-disabled'
+      return 'rev-Pagination-arrow is-disabled'
     } else {
-      return 'Pagination-arrow'
+      return 'rev-Pagination-arrow'
     }
   }
 
@@ -118,14 +118,14 @@ export default class Pagination extends Component {
 
         if (page === currentPage) {
           return (
-            <li key={page} className="Pagination-number current">
+            <li key={page} className="rev-Pagination-number current">
               <span className="show-for-sr">{currentPageText}</span>
               {page}
             </li>
           )
         } else {
           return (
-            <li key={page} className="Pagination-number">
+            <li key={page} className="rev-Pagination-number">
               <a
                 href={href(page)}
                 onClick={this.createClickHandler(page)}
@@ -172,9 +172,9 @@ export default class Pagination extends Component {
       return null
     } else {
       return (
-        <div className={classNames('PaginationWrapper', this.props.className)}>
+        <div className={classNames('rev-PaginationWrapper', this.props.className)}>
           <ul
-            className="Pagination pagination"
+            className="rev-Pagination pagination"
             role="navigation"
             aria-label="Pagination"
           >
@@ -191,11 +191,11 @@ export default class Pagination extends Component {
                 {previousPageContent}
               </a>
             </li>
-            <li className={classNames('Pagination-dots', beginArrows ? '' : 'is-hidden')}>
+            <li className={classNames('rev-Pagination-dots', beginArrows ? '' : 'is-hidden')}>
               ...
             </li>
             {this.numberLinks(start, end)}
-            <li className={classNames('Pagination-dots', endArrows ? '' : 'is-hidden')}>
+            <li className={classNames('rev-Pagination-dots', endArrows ? '' : 'is-hidden')}>
               ...
             </li>
             <li className={endArrowsClass}>
@@ -215,7 +215,7 @@ export default class Pagination extends Component {
               </a>
             </li>
           </ul>
-          <div className="PaginationWrapper-pageList">
+          <div className="rev-PaginationWrapper-pageList">
             {mobilePageListText(currentPage, totalPages)}
           </div>
         </div>

--- a/src/StatelessModal.js
+++ b/src/StatelessModal.js
@@ -21,13 +21,13 @@ export default class StatelessModal extends Component {
 
   render() {
     let className = classNames(this.props.className, {
-      'RevModal': true,
+      'rev-Modal': true,
     })
 
     if(this.props.isOpen) {
       return <div className={className}>
-        <div className="RevModal-background" onClick={this.onBackgroundClick} />
-        <div className="RevModal-content">
+        <div className="rev-Modal-background" onClick={this.onBackgroundClick} />
+        <div className="rev-Modal-content">
           {this.props.children}
         </div>
       </div>


### PR DESCRIPTION
Connects #40 
Connects #60 

Fixes classnames for modals and pagination.

Fixes modal bug (now shows up on example page):
![image](https://cloud.githubusercontent.com/assets/4777393/22380672/d68c3fd0-e483-11e6-9b15-144762766984.png)
