### PR TITLE
Fix Radio.Fieldset bug, test runner bug, and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revelry-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "repository": {
     "type": "",
@@ -59,6 +59,7 @@
     "jsdom-global": "^3.0.2",
     "mocha": "^3.4.2",
     "nyc": "^11.0.3",
+    "react-addons-test-utils": "^15.6.0",
     "react-test-renderer": ">=15.0.0",
     "sinon": "^2.3.8"
   },

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -58,14 +58,16 @@ class RadioFieldset extends Component {
         key: option.key || option.value,
         disabled: option.disabled,
       }
+
+      props.value = option.value
+
       if(isControlled) {
-        props.value = option.value
         props.checked = value == option.value
       }
       if(hasDefault) {
-        props.defaultValue = option.value
         props.defaultChecked = defaultValue == option.value
       }
+
       return <Radio {...props} className="rev-RadioFieldset-radio" />
     })
 

--- a/src/Radio.test.js
+++ b/src/Radio.test.js
@@ -53,4 +53,11 @@ describe('Radio.Fieldset', () => {
 
     expect(radioFieldset.children().first().prop('defaultChecked')).to.eq(true)
   })
+
+  it('should respect option values even when there is no value or defaultValue', () => {
+    const value = 'OPTION_TEST_VALUE'
+    const testOptions = [{value}]
+    const radioFieldset = mount(<Radio.Fieldset options={testOptions} />)
+    expect(radioFieldset.find('input').prop('value')).to.eq(value)
+  })
 })


### PR DESCRIPTION
Tests wouldn't run without that `react-test-utils` package even though it generates a warning. (Might be a we-need-to-bump-`enzyme`-version-soon thing?)

This fixes a bug where a `Radio.Fieldset`, for which both `value` and `defaultValue` are `null`ish, would fail to set the `value` attributes of the contained radio `input`s.