### PR TITLE
Clean up grid examples

### DIFF
--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -21,7 +21,8 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js'",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "cache:clean": "yes | rm -r .cache public node_modules",
   },
   "devDependencies": {
     "prettier": "^1.5.2"

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -22,7 +22,7 @@
     "develop": "gatsby develop",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "cache:clean": "yes | rm -r .cache public node_modules",
+    "cache:rebuild": "yarn cache clean && yarn install --force"
   },
   "devDependencies": {
     "prettier": "^1.5.2"

--- a/docs-src/src/examples/grid/BlockGrids.js.example
+++ b/docs-src/src/examples/grid/BlockGrids.js.example
@@ -1,20 +1,20 @@
-<Row smallUp={1} mediumUp={2} largeUp={4}>
+<Row smallUp={1} mediumUp={2} largeUp={4} className="ColumnExamples">
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
   <Col>
-    <img src="//placehold.it/300x300" className="thumbnail" alt="" />
+    <img src="//placekitten.com/g/300/300" className="thumbnail" alt="" />
   </Col>
 </Row>

--- a/docs-src/src/examples/grid/CenteredColumns.js.example
+++ b/docs-src/src/examples/grid/CenteredColumns.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col small={3} smallCentered>3 centered</Col>
   </Row>

--- a/docs-src/src/examples/grid/CenteredColumns.js.example
+++ b/docs-src/src/examples/grid/CenteredColumns.js.example
@@ -6,7 +6,9 @@
     <Col small={6} smallCentered>6 centered</Col>
   </Row>
   <Row>
-    <Col small={9} smallCentered largeUncentered>9 centered</Col>
+    <Col small={9} smallCentered largeUncentered>
+      9 centered, largeUncentered
+    </Col>
   </Row>
   <Row>
     <Col small={11} smallCentered>11 centered</Col>

--- a/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
@@ -1,21 +1,21 @@
 <div className="ColumnExamples">
-  <Row>
+  <Row flex left>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the left</Col>
   </Row>
-  <Row right>
+  <Row flex right>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the right</Col>
   </Row>
-  <Row center>
+  <Row flex center>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the middle</Col>
   </Row>
-  <Row justify>
+  <Row flex justify>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the edges</Col>
   </Row>
-  <Row spaced>
+  <Row flex spaced>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the space around</Col>
   </Row>

--- a/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/HorizontalAlignmentOnRow.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col small={4}>Aligned to</Col>
     <Col small={4}>the left</Col>

--- a/docs-src/src/examples/grid/IncompleteRowsWithoutFlexGrid.js.example
+++ b/docs-src/src/examples/grid/IncompleteRowsWithoutFlexGrid.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col medium={3}>3</Col>
     <Col medium={3}>3</Col>

--- a/docs-src/src/examples/grid/Intro.js.example
+++ b/docs-src/src/examples/grid/Intro.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col small={2} large={4}>x</Col>
     <Col small={4} large={4}>x</Col>

--- a/docs-src/src/examples/grid/Nesting.js.example
+++ b/docs-src/src/examples/grid/Nesting.js.example
@@ -1,9 +1,9 @@
-<Row>
+<Row className="ColumnExamples">
   <Col small={8}>8
     <Row>
-      <Col small={8}>8 Nested
+      <Col small={8}>8
         <Row>
-          <Col small={8}>8 Nested Again</Col>
+          <Col small={8}>8</Col>
           <Col small={4}>4</Col>
         </Row>
       </Col>

--- a/docs-src/src/examples/grid/Offsets.js.example
+++ b/docs-src/src/examples/grid/Offsets.js.example
@@ -1,18 +1,18 @@
 <div className="ColumnExamples">
   <Row>
-    <Col large={1}>1</Col>
-    <Col large={11}>11</Col>
+    <Col large={2}>2</Col>
+    <Col large={10}>10</Col>
   </Row>
   <Row>
-    <Col large={1}>1</Col>
-    <Col large={10} largeOffset={1}>10, offset 1</Col>
+    <Col large={2}>2</Col>
+    <Col large={9} largeOffset={1}>9, offset 1</Col>
   </Row>
   <Row>
-    <Col large={1}>1</Col>
-    <Col large={9} largeOffset={2}>9, offset 2</Col>
+    <Col large={2}>2</Col>
+    <Col large={8} largeOffset={2}>8, offset 2</Col>
   </Row>
   <Row>
-    <Col large={1}>1</Col>
-    <Col large={8} largeOffset={3}>8, offset 3</Col>
+    <Col large={2}>2</Col>
+    <Col large={7} largeOffset={3}>7, offset 3</Col>
   </Row>
 </div>

--- a/docs-src/src/examples/grid/Offsets.js.example
+++ b/docs-src/src/examples/grid/Offsets.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col large={1}>1</Col>
     <Col large={11}>11</Col>

--- a/docs-src/src/examples/grid/RowCollapse.js.example
+++ b/docs-src/src/examples/grid/RowCollapse.js.example
@@ -1,4 +1,4 @@
-<Row mediumUncollapse largeUncollapse className="ColumnExamples">
+<Row mediumUncollapse largeCollapse className="ColumnExamples">
   <Col small={6}>
     Removes gutter at large media query
   </Col>

--- a/docs-src/src/examples/grid/RowCollapse.js.example
+++ b/docs-src/src/examples/grid/RowCollapse.js.example
@@ -1,4 +1,4 @@
-<Row mediumUncollapse largeUncollapse>
+<Row mediumUncollapse largeUncollapse className="ColumnExamples">
   <Col small={6}>
     Removes gutter at large media query
   </Col>

--- a/docs-src/src/examples/grid/Shrink.js.example
+++ b/docs-src/src/examples/grid/Shrink.js.example
@@ -1,4 +1,4 @@
-<Row>
-  <Col shrink><div style={{backgroundColor: '#ffff99'}}>shrunk</div></Col>
+<Row className="ColumnExamples">
+  <Col shrink>shrunk</Col>
   <Col>remainder</Col>
 </Row>

--- a/docs-src/src/examples/grid/Shrink.js.example
+++ b/docs-src/src/examples/grid/Shrink.js.example
@@ -1,4 +1,4 @@
-<Row className="ColumnExamples">
+<Row className="ColumnExamples" flex>
   <Col shrink>shrunk</Col>
   <Col>remainder</Col>
 </Row>

--- a/docs-src/src/examples/grid/SourceOrderingWithFlexGrid.js.example
+++ b/docs-src/src/examples/grid/SourceOrderingWithFlexGrid.js.example
@@ -1,4 +1,4 @@
-<Row>
+<Row className="ColumnExamples">
   <Col smallOrder={2} mediumOrder={1}>
     This column will come second on small, and first on medium and larger.
   </Col>

--- a/docs-src/src/examples/grid/SourceOrderingWithFlexGrid.js.example
+++ b/docs-src/src/examples/grid/SourceOrderingWithFlexGrid.js.example
@@ -1,8 +1,8 @@
-<Row className="ColumnExamples">
-  <Col smallOrder={2} mediumOrder={1}>
-    This column will come second on small, and first on medium and larger.
+<Row flex className="ColumnExamples">
+  <Col mediumOrder={2} largeOrder={1}>
+    This column will come second on medium, and first on large.
   </Col>
-  <Col smallOrder={1} mediumOrder={2}>
-    This column will come first on small, and second on medium and larger.
+  <Col mediumOrder={1} largeOrder={2}>
+    This column will come first on medium, and second on large.
   </Col>
 </Row>

--- a/docs-src/src/examples/grid/SourceOrderingWithoutFlexGrid.js.example
+++ b/docs-src/src/examples/grid/SourceOrderingWithoutFlexGrid.js.example
@@ -1,22 +1,22 @@
 <div className="ColumnExamples">
   <Row>
-    <Col small={10} smallPush={2}>10</Col>
-    <Col small={2} smallPull={10}>2, last</Col>
+    <Col small={10} smallPush={2}>1st</Col>
+    <Col small={2} smallPull={10}>2nd</Col>
   </Row>
   <Row>
-    <Col large={9} largePush={3}>9</Col>
-    <Col large={3} largePull={9}>3, last</Col>
+    <Col large={9} largePush={3}>1st</Col>
+    <Col large={3} largePull={9}>2nd</Col>
   </Row>
   <Row>
-    <Col large={8} largePush={4}>8</Col>
-    <Col large={4} largePull={8}>4, last</Col>
+    <Col large={8} largePush={4}>1st</Col>
+    <Col large={4} largePull={8}>2nd</Col>
   </Row>
   <Row>
-    <Col small={5} smallPush={7}>7</Col>
-    <Col small={7} smallPull={5}>5, last</Col>
+    <Col small={5} smallPush={7}>1st</Col>
+    <Col small={7} smallPull={5}>2nd</Col>
   </Row>
   <Row>
-    <Col medium={6} mediumPush={6}>6</Col>
-    <Col medium={6} mediumPull={6}>6, last</Col>
+    <Col medium={6} mediumPush={6}>1st</Col>
+    <Col medium={6} mediumPull={6}>2nd</Col>
   </Row>
 </div>

--- a/docs-src/src/examples/grid/SourceOrderingWithoutFlexGrid.js.example
+++ b/docs-src/src/examples/grid/SourceOrderingWithoutFlexGrid.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row>
     <Col small={10} smallPush={2}>10</Col>
     <Col small={2} smallPull={10}>2, last</Col>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
@@ -1,8 +1,22 @@
-<Row className="ColumnExamples">
-  <Col bottom>Align bottom</Col>
-  <Col middle>Align middle</Col>
-  <Col top>Align top</Col>
-  <Col>
-    <Lipsum />
-  </Col>
-</Row>
+<div>
+  <Row flex className="ColumnExamples">
+    <Col bottom small={6}>Align bottom</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+
+  <Row flex className="ColumnExamples">
+    <Col middle small={6}>Align middle</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+
+  <Row flex className="ColumnExamples">
+    <Col top small={6}>Align top</Col>
+    <Col small={6}>
+      <Lipsum />
+    </Col>
+  </Row>
+</div>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnCol.js.example
@@ -1,4 +1,4 @@
-<Row>
+<Row className="ColumnExamples">
   <Col bottom>Align bottom</Col>
   <Col middle>Align middle</Col>
   <Col top>Align top</Col>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
@@ -1,46 +1,26 @@
 <div className="ColumnExamples">
-  <Row middle>
-    <Col>I{"'"}m in the middle!</Col>
-    <Col>
-      I am as well, but I have so much text I take up more space! 
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. 
-      Quis facere ducimus earum minus, inventore, ratione doloremque 
-      deserunt neque perspiciatis accusamus explicabo soluta, 
-      quod provident distinctio aliquam omnis? Labore, ullam 
-      possimus.
+  <Row middle flex>
+    <Col small={6}>I&apos;m in the middle!</Col>
+    <Col small={6}>
+      <Lipsum />
     </Col>
   </Row>
-  <hr />
-  <Row top>
-    <Col>These columns align to the top.</Col>
-    <Col>
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. 
-      Voluptatum, tempora. Impedit eius officia possimus 
-      laudantium? Molestiae eaque, sapiente atque doloremque 
-      placeat! In sint, fugiat saepe sunt dolore tempore amet 
-      cupiditate.
+  <Row top flex>
+    <Col small={6}>These columns align to the top.</Col>
+    <Col small={6}>
+      <Lipsum />
     </Col>
   </Row>
-  <hr />
-  <Row bottom>
-    <Col>bottom</Col>
-    <Col>
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. 
-      Voluptatum, tempora. Impedit eius officia possimus 
-      laudantium? Molestiae eaque, sapiente atque doloremque 
-      placeat! In sint, fugiat saepe sunt dolore tempore amet 
-      cupiditate.
+  <Row bottom flex>
+    <Col small={6}>bottom</Col>
+    <Col small={6}>
+      <Lipsum />
     </Col>
   </Row>
-  <hr />
-  <Row>
-    <Col>unspecified simply fills all vertical space</Col>
-    <Col>
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. 
-      Voluptatum, tempora. Impedit eius officia possimus 
-      laudantium? Molestiae eaque, sapiente atque doloremque 
-      placeat! In sint, fugiat saepe sunt dolore tempore amet 
-      cupiditate.
+  <Row flex>
+    <Col small={6}>unspecified simply fills all vertical space</Col>
+    <Col small={6}>
+      <Lipsum />
     </Col>
   </Row>
 </div>

--- a/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
+++ b/docs-src/src/examples/grid/VerticalAlignmentOnRow.js.example
@@ -1,4 +1,4 @@
-<div>
+<div className="ColumnExamples">
   <Row middle>
     <Col>I{"'"}m in the middle!</Col>
     <Col>

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -44,10 +44,40 @@
     width: 100%;
   }
 }
+// For grid example pages, colorize columns and mark the edges, and put spacing between rows
 .ColumnExamples {
-  .columns {
-    text-align: center;
+  &.rev-Row,
+  .rev-Row {
+    margin-bottom: $global-vertical-space;
+    .rev-Row {
+      margin-bottom: 0;
+    }
   }
+  .rev-Col {
+    text-align: center;
+    background-clip: content-box;
+    position: relative;
+    // All of this is a way to put an outline-esque border on the left and 
+    // right edge without taking up space (doing it this way, because outline
+    // can't be applied to only left and right).
+    // If we just put left and right borders, it can cause weird overflows
+    // and wrapping with the grid, which is bad for a grid demo page
+    &:before {
+      // Needs content to be placed in DOM
+      content: ' ';
+      // Position to be the same size and location as the column
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      // Mark left and right edges
+      border-left: 1px dashed $gray;
+      border-right: 1px dashed $gray;
+    }
+  }
+  // Throw some grayscale colors on the grid columns to show what space they 
+  // occupy
   .columns:nth-child(6n+1) {
     @include color-stack($gray);
   }
@@ -67,6 +97,7 @@
   .columns:nth-child(6n+6) {
     @include color-stack($lighter-gray);
   }
+  // For nesting example, show the extents of the nested row
   .columns .row {
     outline: 1px solid $white;
   }

--- a/docs-src/src/layouts/index.scss
+++ b/docs-src/src/layouts/index.scss
@@ -44,3 +44,30 @@
     width: 100%;
   }
 }
+.ColumnExamples {
+  .columns {
+    text-align: center;
+  }
+  .columns:nth-child(6n+1) {
+    @include color-stack($gray);
+  }
+  .columns:nth-child(6n+2) {
+    @include color-stack($black);
+    
+  }
+  .columns:nth-child(6n+3) {
+    @include color-stack($darker-gray);
+  }
+  .columns:nth-child(6n+4) {
+    @include color-stack($dark-gray);
+  }
+  .columns:nth-child(6n+5) {
+    @include color-stack($light-gray);
+  }
+  .columns:nth-child(6n+6) {
+    @include color-stack($lighter-gray);
+  }
+  .columns .row {
+    outline: 1px solid $white;
+  }
+}

--- a/docs-src/src/pages/components/grid.js
+++ b/docs-src/src/pages/components/grid.js
@@ -4,23 +4,46 @@ import scope from '../../ExampleScope'
 
 const examples = {
   'Intro': require('raw!../../examples/grid/Intro.js.example'),
-  'Nesting': require('raw!../../examples/grid/Nesting.js.example'),
-  'Offsets': require('raw!../../examples/grid/Offsets.js.example'),
-  'Shrink': require('raw!../../examples/grid/Shrink.js.example'),
-  'Row Collapse': require('raw!../../examples/grid/RowCollapse.js.example'),
-  'Block Grid': require('raw!../../examples/grid/BlockGrids.js.example'),
-  'Source Ordering With Flex Grid': require('raw!../../examples/grid/SourceOrderingWithFlexGrid.js.example'),
-  'Source Ordering Without Flex Grid': require('raw!../../examples/grid/SourceOrderingWithoutFlexGrid.js.example'),
-  'Vertical Alignment On Col': require('raw!../../examples/grid/VerticalAlignmentOnCol.js.example'),
-  'Vertical Alignment On Row': require('raw!../../examples/grid/VerticalAlignmentOnRow.js.example'),
-  'Incomplete Rows Without Flex Grid': require('raw!../../examples/grid/IncompleteRowsWithoutFlexGrid.js.example'),
-  'Horizontal Alignment On Row': require('raw!../../examples/grid/HorizontalAlignmentOnRow.js.example'),
-  'Centered Columns': require('raw!../../examples/grid/CenteredColumns.js.example'),
+  'Flex Grid': {
+    'Shrink': require('raw!../../examples/grid/Shrink.js.example'),
+    'Source Ordering With Flex Grid': require('raw!../../examples/grid/SourceOrderingWithFlexGrid.js.example'),
+    'Vertical Alignment On Col': require('raw!../../examples/grid/VerticalAlignmentOnCol.js.example'),
+    'Vertical Alignment On Row': require('raw!../../examples/grid/VerticalAlignmentOnRow.js.example'),
+    'Horizontal Alignment On Row': require('raw!../../examples/grid/HorizontalAlignmentOnRow.js.example'),
+  },
+  'Float Grid': {
+    'Nesting': require('raw!../../examples/grid/Nesting.js.example'),
+    'Offsets': require('raw!../../examples/grid/Offsets.js.example'),
+    'Row Collapse': require('raw!../../examples/grid/RowCollapse.js.example'),
+    'Block Grid': require('raw!../../examples/grid/BlockGrids.js.example'),
+    'Source Ordering With Float Grid': require('raw!../../examples/grid/SourceOrderingWithoutFlexGrid.js.example'),
+    'Incomplete Rows With Float Grid': require('raw!../../examples/grid/IncompleteRowsWithoutFlexGrid.js.example'),
+    'Centered Columns': require('raw!../../examples/grid/CenteredColumns.js.example'),
+  },
 }
 
 export default class gridExamplePage extends Component {
   render() {
     return <div>
+      <h1>Grid</h1>
+      <p>
+        Note: the examples on this page have been specifically styled to make 
+        normally invisible grid elements visible. These non-standard styles:
+      </p>
+      <ul>
+        <li>
+          Content areas of grid columns have been given backgrounds to 
+          demonstrate their bounds.
+        </li>
+        <li>
+          The left and right edges of the columns have been marked with a 
+          dashed line to demonstrate the extent of the grid gutters.
+        </li>
+        <li>
+          Nested grid rows have been given a white outline to demonstrate
+          their bounds.
+        </li>
+      </ul>
       <ExampleSection title="Examples" examples={examples} depth={1} scope={scope} />
     </div>
   }

--- a/scss/components/_BlockGrid.scss
+++ b/scss/components/_BlockGrid.scss
@@ -3,27 +3,35 @@
 // BLOCK GRID
 @for $i from 1 through $grid-columns {
   .rev-Row--smallUp#{$i} {
+    flex-wrap: wrap;
     .rev-Col {
+      flex: 0 0 auto;
       width: calc(100% / #{$i});
     }
   }
   @include breakpoint($medium) {
     .rev-Row--mediumUp#{$i} {
+      flex-wrap: wrap;
       .rev-Col {
+        flex: 0 0 auto;
         width: calc(100% / #{$i});
       }
     }
   }
   @include breakpoint($medium) {
     .rev-Row--largeUp#{$i} {
+      flex-wrap: wrap;
       .rev-Col {
+        flex: 0 0 auto;
         width: calc(100% / #{$i});
       }
     }
   }
   @include breakpoint($medium) {
     .rev-Row--xlargeUp#{$i} {
+      flex-wrap: wrap;
       .rev-Col {
+        flex: 0 0 auto;
         width: calc(100% / #{$i});
       }
     }
@@ -31,6 +39,7 @@
   @include breakpoint($medium) {
     .rev-Row--xxlargeUp#{$i} {
       .rev-Col {
+        flex: 0 0 auto;
         width: calc(100% / #{$i});
       }
     }

--- a/scss/components/_FlexGrid.scss
+++ b/scss/components/_FlexGrid.scss
@@ -5,9 +5,11 @@
 .rev-Row--center {
   @include flexJustifyCenter;
 }
+.rev-Row--spaced,
 .rev-Row--spaceAround {
   @include flexJustifySpaceAround;
 }
+.rev-Row--justify,
 .rev-Row--spaceBetween {
   @include flexJustifySpaceBetween;
 }
@@ -80,6 +82,53 @@
   @for $i from 0 through $grid-columns {
     .rev-Col--xxlargeOrder#{$i} {
       order: $i;
+    }
+  }
+}
+
+// Set max-widths and flex-basis for numerical columns so they are contained
+// instead of expanding to take over the whole row
+@for $i from 1 through $grid-columns {
+  .rev-Row--flex.rev-Row--flex .rev-Col--small#{$i}.rev-Col--small#{$i} {
+    flex-basis: 100% / $grid-columns * $i;
+    max-width: 100% / $grid-columns * $i;
+    width: auto;
+  }
+}
+
+@include breakpoint($medium)  {
+  @for $i from 1 through $grid-columns {
+    .rev-Row--flex.rev-Row--flex .rev-Col--medium#{$i}.rev-Col--medium#{$i} {
+      flex-basis: 100% / $grid-columns * $i;
+      max-width: 100% / $grid-columns * $i;
+      width: auto;
+    }
+  }
+}
+@include breakpoint($large)  {
+  @for $i from 1 through $grid-columns {
+    .rev-Row--flex.rev-Row--flex .rev-Col--large#{$i}.rev-Col--large#{$i} {
+      flex-basis: 100% / $grid-columns * $i;
+      max-width: 100% / $grid-columns * $i;
+      width: auto;
+    }
+  }
+}
+@include breakpoint($xlarge) {
+  @for $i from 1 through $grid-columns {
+    .rev-Row--flex.rev-Row--flex .rev-Col--xlarge#{$i}.rev-Col--xlarge#{$i} {
+      flex-basis: 100% / $grid-columns * $i;
+      max-width: 100% / $grid-columns * $i;
+      width: auto;
+    }
+  }
+}
+@include breakpoint($xxlarge)  {
+  @for $i from 1 through $grid-columns {
+    .rev-Row--flex.rev-Row--flex .rev-Col--xxlarge#{$i}.rev-Col--xxlarge#{$i} {
+      flex-basis: 100% / $grid-columns * $i;
+      max-width: 100% / $grid-columns * $i;
+      width: auto;
     }
   }
 }

--- a/scss/components/_Grid.scss
+++ b/scss/components/_Grid.scss
@@ -10,6 +10,13 @@
   &.rev-Row--flex,
   &.rev-Row--smallFlex, {
     display: flex;
+    flex-flow: row wrap;
+    .rev-Col {
+      flex: 1 1 0px;
+    }
+    .shrink {
+      flex: 0 0 auto;
+    }
   }
   &.rev-Row--unflex,
   &.rev-Row--smallUnflex {
@@ -32,6 +39,9 @@
       padding-left: $grid-column-padding;
       padding-right: $grid-column-padding;
     }
+  }
+  &.rev-Row--right {
+    justify-content: flex-end;
   }
   @include breakpoint($medium)  {
     &.rev-Row--mediumFlex {
@@ -133,6 +143,8 @@
 
 // COLUMNS
 .rev-Col {
+  flex-grow: 1;
+  flex-shrink: 0;
   float: left;
   padding: 0 $grid-column-padding;
   position: relative;
@@ -150,6 +162,15 @@
 .rev-Col--Uncentered,
 .rev-Col--smallUncentered {
   float: left;
+}
+.rev-Col--bottom {
+  align-self: flex-end;
+}
+.rev-Col--middle {
+  align-self: center;
+}
+.rev-Col--top {
+  align-self: flex-start;
 }
 
 @for $i from 1 through $grid-columns {

--- a/scss/components/_Layout.scss
+++ b/scss/components/_Layout.scss
@@ -3,7 +3,6 @@
 .rev-Split {
   @extend .rev-Row;
   @extend .rev-Row--collapse;
-  @extend .rev-Row--flex;
   padding: 0;
 }
 .rev-MainPanel {

--- a/scss/vars/_colors.scss
+++ b/scss/vars/_colors.scss
@@ -56,6 +56,19 @@ $muted: $lighter-gray;
 $very-muted: $lightest-gray;
 $disabled: $lighter-gray;
 
+@mixin color-stack($bg) {
+  background-color: $bg;
+  @if lightness($bg) < lightness(#888) {
+    color: $body-bkgd;
+    a {
+      color: $body-bkgd;
+    }
+  }
+  @else {
+    color: $body-font-color;
+  }
+}
+
 @mixin body-color-stack {
   background-color: $body-bkgd;
   color: $body-font-color;

--- a/src/Row.js
+++ b/src/Row.js
@@ -24,6 +24,7 @@ const BOOL_PROPS_TO_CLASS_NAMES = {
   middle: ['align-middle', 'rev-Row--middle'],
   bottom: ['align-bottom', 'rev-Row--bottom'],
   stretch: ['align-stretch', 'rev-Row--stretch'],
+  flex: ['rev-Row--flex'],
 }
 
 const BOOL_PROPS = Object.keys(BOOL_PROPS_TO_CLASS_NAMES)


### PR DESCRIPTION
Temp site if you want to play with this in a browser: http://gratis-quill.surge.sh

I cleaned up the grid examples to make sure they all work with our default SCSS. I had to make some tweaks / additions to our grid code from the base SCSS to do it. I also tried to make the examples as clear as possible by removing unneeded markup and changing some of the column labels.